### PR TITLE
Fixed installation of check-mongodb.py

### DIFF
--- a/sensu-plugins-mongodb.gemspec
+++ b/sensu-plugins-mongodb.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
                               monitoring, collection-specific metrics, and
                               more.'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
+  s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-mongodb'
   s.license                = 'MIT'


### PR DESCRIPTION
Globing pattern don't pick the `.py` extension, so we need to make it less specific.

Fixes #11.