### PR TITLE
Fix General MongoDB Error: can't set attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Setting read preference for pymongo 2.2+ in check-mongodb.py
 
 ## [1.1.0] - 2016-10-17
 ### Added

--- a/bin/check-mongodb.py
+++ b/bin/check-mongodb.py
@@ -319,7 +319,9 @@ def exit_with_general_critical(e):
 
 
 def set_read_preference(db):
-    if pymongo.version >= "2.1":
+    if pymongo.version >= "2.2":
+        pymongo.read_preferences.Secondary
+    else:
         db.read_preference = pymongo.ReadPreference.SECONDARY
 
 


### PR DESCRIPTION
## Pull Request Checklist

No existing issue

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

This path fixes options `replication_lag` and `replication_lag_percent` of `check-mongodb.py` causing `General MongoDB Error: can't set attribute` with newest versions of pymongo. It reflects an upstream change made a long time ago at https://github.com/mzupan/nagios-plugin-mongodb/commit/09ac8e25d5bf7ca91cc8468e0fcdf44f00d52e50.

#### Known Compatablity Issues

