### PR TITLE
Fixed #37 - Sort replication members to ensure the primary is the first element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - Setting read preference for pymongo 2.2+ in check-mongodb.py
+- Sort replication members to ensure the primary is the first element in metrics-mongodb-replication.rb
 
 ## [1.1.0] - 2016-10-17
 ### Added

--- a/bin/metrics-mongodb-replication.rb
+++ b/bin/metrics-mongodb-replication.rb
@@ -192,11 +192,11 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
       replication_members = replication_status['members']
       unless replication_members.nil?
         state_map = {
-          "PRIMARY" => 1,
-          "SECONDARY" => 2
+          'PRIMARY' => 1,
+          'SECONDARY' => 2
         }
         state_map.default = 3
-        replication_members.sort! {|x, y| state_map[x['stateStr']] <=> state_map[y['stateStr']]}
+        replication_members.sort! { |x, y| state_map[x['stateStr']] <=> state_map[y['stateStr']] }
 
         replication_members.each do |replication_member_details|
           metrics.update(gather_replication_member_metrics(replication_member_details))

--- a/bin/metrics-mongodb-replication.rb
+++ b/bin/metrics-mongodb-replication.rb
@@ -191,6 +191,13 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
       metrics = {}
       replication_members = replication_status['members']
       unless replication_members.nil?
+        state_map = {
+          "PRIMARY" => 1,
+          "SECONDARY" => 2
+        }
+        state_map.default = 3
+        replication_members.sort! {|x, y| state_map[x['stateStr']] <=> state_map[y['stateStr']]}
+
         replication_members.each do |replication_member_details|
           metrics.update(gather_replication_member_metrics(replication_member_details))
           member_id = replication_member_details['_id']


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
yes, the issue is #37 
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Solve problems with the check when the first element on the replication members are not `PRIMARY`. 

#### Known Compatablity Issues

