### PR TITLE
closes #30 by ensuring that we make a request immediately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- `check-mongodb.py`: will now correctly crit on connection issues (@majormoses)
 ## [1.2.1] - 2017-05-07
 ### Fixed
 - `check-mongodb.py`: fixed issue of param building with not/using ssl connections (@s-schweer)

--- a/bin/check-mongodb.py
+++ b/bin/check-mongodb.py
@@ -278,15 +278,21 @@ def mongo_connect(host=None, port=None, ssl_enabled=False, ssl_certfile=None, ss
         # ssl connection for pymongo > 2.3
         if pymongo.version >= "2.3":
             if replica is None:
-                if ssl_enabled:  
+                if ssl_enabled:
                     con = pymongo.MongoClient(host, port, ssl=ssl_enabled, ssl_certfile=ssl_certfile, ssl_keyfile=ssl_keyfile, ssl_ca_certs=ssl_ca_certs)
-                else: 
+                else:
                     con = pymongo.MongoClient(host, port)
             else:
-                if ssl_enabled: 
+                if ssl_enabled:
                     con = pymongo.Connection(host, port, read_preference=pymongo.ReadPreference.SECONDARY, ssl=ssl_enabled, ssl_certfile=ssl_certfile, ssl_keyfile=ssl_keyfile, ssl_ca_certs=ssl_ca_certs, replicaSet=replica, network_timeout=10)
-                else: 
+                else:
                     con = pymongo.Connection(host, port, read_preference=pymongo.ReadPreference.SECONDARY, replicaSet=replica, network_timeout=10)
+            try:
+                # https://api.mongodb.com/python/current/api/pymongo/mongo_client.html
+                # The ismaster command is cheap and does not require auth.
+                con.admin.command('ismaster', connectTimeoutMS=10000)
+            except Exception, e:
+                return exit_with_general_critical(e), None
         else:
             if replica is None:
                 con = pymongo.Connection(host, port, slave_okay=True, network_timeout=10)


### PR DESCRIPTION
from the mongo docs https://api.mongodb.com/python/current/api/pymongo/mongo_client.html:
```
Starting with version 3.0 the MongoClient constructor no longer blocks while connecting to the server or servers, and it no longer raises ConnectionFailure if they are unavailable, nor ConfigurationError if the user’s credentials are wrong. Instead, the constructor returns immediately and launches the connection process on background threads.
```

Verification that it fails on nodes not running mongo now:
```
$ ./bin/check-mongodb.rb 
CRITICAL - General MongoDB Error: 127.0.0.1:27017: [Errno 111] Connection refused
```

Verification that it connects sucessfully when mongo is reachable:
```
$ ./bin/check-mongodb.rb --host 10.55.150.42 --port 27000
OK - Connection took 0 seconds
```

Intentionally provide bad credentials:
```
$ ./bin/check-mongodb.rb --host 10.55.150.42 --port 27000 --user foo --pass foo
CRITICAL - General MongoDB Error: Authentication failed.
```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
If unable to connect to mongo we should get an error and not a silent OK.
#### Known Compatablity Issues
none that I know of.
