### PR TITLE
fix secondary read preference for 2.8

### DIFF
--- a/bin/check-mongodb.py
+++ b/bin/check-mongodb.py
@@ -331,7 +331,7 @@ def exit_with_general_critical(e):
 
 
 def set_read_preference(db):
-    if pymongo.version >= "2.2":
+    if pymongo.version >= "2.2" and pymongo.version < "2.8":
         pymongo.read_preferences.Secondary
     else:
         db.read_preference = pymongo.ReadPreference.SECONDARY


### PR DESCRIPTION
## Pull Request Checklist

This fixes the issue with pymongo 2.8 mentioned in https://github.com/sensu-plugins/sensu-plugins-mongodb/issues/41. I have not tested any other versions, so not quite sure if this is correct logic for versions > 2.8. 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
