### PR TITLE
Add option to exclude database sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Added
+- `bin/metrics-mongodb.rb`: added `--exclude-db-sizes` option that removes database sizes which can be quite large from the payload sent to message broker (rabbitmq) which often need special tuning for (@mdzidic)
+
 ## [2.0.2] - 2018-03-17
 ### Fixed
 - renamed library file `metics` to `metrics` and updated all refrences in code to it (@majormoses)

--- a/bin/metrics-mongodb.rb
+++ b/bin/metrics-mongodb.rb
@@ -98,7 +98,12 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Require the node to be a master node',
          long: '--require-master',
          default: false
-
+  
+  option :exclude_db_sizes,
+         description: 'Exclude database sizes',
+         long: '--exclude-db-sizes',
+         default: false
+  
   def run
     Mongo::Logger.logger.level = Logger::FATAL
     @debug = config[:debug]
@@ -114,7 +119,8 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
     collector.connect_mongo_db('admin')
     exit(1) if config[:require_master] && !collector.master?
     metrics = collector.server_metrics
-
+    metrics = metrics.select {|k,v| !k[/databaseSizes/]} if config[:exclude_db_sizes]
+    
     # Print them in graphite format.
     timestamp = Time.now.to_i
     metrics.each do |k, v|

--- a/bin/metrics-mongodb.rb
+++ b/bin/metrics-mongodb.rb
@@ -98,12 +98,12 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Require the node to be a master node',
          long: '--require-master',
          default: false
- 
+
   option :exclude_db_sizes,
          description: 'Exclude database sizes',
          long: '--exclude-db-sizes',
          default: false
- 
+
   def run
     Mongo::Logger.logger.level = Logger::FATAL
     @debug = config[:debug]

--- a/bin/metrics-mongodb.rb
+++ b/bin/metrics-mongodb.rb
@@ -119,7 +119,7 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
     collector.connect_mongo_db('admin')
     exit(1) if config[:require_master] && !collector.master?
     metrics = collector.server_metrics
-    metrics = metrics.select { |k,v| !k[/databaseSizes/] } if config[:exclude_db_sizes]
+    metrics = metrics.select { |k, _v| !k[/databaseSizes/] } if config[:exclude_db_sizes]
 
     # Print them in graphite format.
     timestamp = Time.now.to_i

--- a/bin/metrics-mongodb.rb
+++ b/bin/metrics-mongodb.rb
@@ -119,7 +119,7 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
     collector.connect_mongo_db('admin')
     exit(1) if config[:require_master] && !collector.master?
     metrics = collector.server_metrics
-    metrics = metrics.select { |k, _v| !k[/databaseSizes/] } if config[:exclude_db_sizes]
+    metrics = metrics.reject { |k, _v| k[/databaseSizes/] } if config[:exclude_db_sizes]
 
     # Print them in graphite format.
     timestamp = Time.now.to_i

--- a/bin/metrics-mongodb.rb
+++ b/bin/metrics-mongodb.rb
@@ -98,12 +98,12 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Require the node to be a master node',
          long: '--require-master',
          default: false
-  
+ 
   option :exclude_db_sizes,
          description: 'Exclude database sizes',
          long: '--exclude-db-sizes',
          default: false
-  
+ 
   def run
     Mongo::Logger.logger.level = Logger::FATAL
     @debug = config[:debug]
@@ -119,8 +119,8 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
     collector.connect_mongo_db('admin')
     exit(1) if config[:require_master] && !collector.master?
     metrics = collector.server_metrics
-    metrics = metrics.select {|k,v| !k[/databaseSizes/]} if config[:exclude_db_sizes]
-    
+    metrics = metrics.select { |k,v| !k[/databaseSizes/] } if config[:exclude_db_sizes]
+
     # Print them in graphite format.
     timestamp = Time.now.to_i
     metrics.each do |k, v|


### PR DESCRIPTION
When You have thousands of collections inside MongoDB you get large metrics payload which Sensu RabbitMQ can't handle without custom tuning.

Excluding database sizes You can still get service metrics.

## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
None